### PR TITLE
Only restart if rucoa.base related config is changed

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ const clientByFolder: Map<WorkspaceFolder, LanguageClient> = new Map();
 
 export function activate(context: ExtensionContext) {
   workspace.onDidChangeConfiguration((event) => {
-    if (event.affectsConfiguration("rucoa")) {
+    if (event.affectsConfiguration("rucoa.base")) {
       restartClients();
     }
   });


### PR DESCRIPTION
To avoid unnecessary restarts.
(Maybe it shouldn't restart also when rucoa.base.debug is change, but I leave it as it is for now.)
